### PR TITLE
chore: patch tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 composer.lock
 .DS_Store
 Thumbs.db
+.phpunit.cache
+.phpunit.result.cache

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
->
-    <testsuites>
-        <testsuite name="Laravel-Userstamps Test Suite">
-            <directory suffix=".php">./tests/</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" colors="true" processIsolation="false" stopOnError="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Laravel-Userstamps Test Suite">
+      <directory suffix=".php">./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/UserstampsTest.php
+++ b/tests/UserstampsTest.php
@@ -15,7 +15,7 @@ class UserstampsTest extends TestCase
      *
      * @var array
      */
-    protected $afterApplicationCreatedCallbacks = [
+    protected array $afterApplicationCreatedCallbacks = [
         'UserstampsTest::handleSetup',
     ];
 


### PR DESCRIPTION
Whilst working on another PR and running phpunit, I've noticed the following error on php ^8.2:

```
➜ ./vendor/bin/phpunit           
PHP Fatal error:  Type of UserstampsTest::$afterApplicationCreatedCallbacks must be array (as in class Orchestra\Testbench\TestCase) in tests/UserstampsTest.php on line 11
```

After fixing that by type hinting array in the UserstampsTest::$afterApplicationCreatedCallbacks property,  phpunit was complaining about a deprecated schema. I updated that by running `./vendor/bin/phpunit --migrate-configuration`, then added the phpunit result cache to .gitignore.

After making the appropriate updates to the tests, the tests are in fact green and passing on php8.2 and php8.3.