### PR TITLE
feat: create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/tests              export-ignore
+/.editorconfig      export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.styleci.yml       export-ignore
+/phpunit.xml.dist   export-ignore


### PR DESCRIPTION
when installed by composer in the vendor directory, these files and folders are excluded.